### PR TITLE
Add marketing site scaffold

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Contact — On Pace For</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header><a href="index.html">← Home</a></header>
+  <h1>Get in Touch</h1>
+  <p>Questions or feedback? Drop us a line:</p>
+  <form action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
+    <label>Email:<input type="email" name="email" required></label><br>
+    <label>Message:<textarea name="message" rows="5" required></textarea></label><br>
+    <button type="submit">Send</button>
+  </form>
+</body>
+</html>

--- a/features.html
+++ b/features.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Features — On Pace For</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header><a href="index.html">← Home</a></header>
+  <h1>Features</h1>
+
+  <article>
+    <h2>Live Progress Dashboard</h2>
+    <p>See your steps, distance, and workouts update in real time.</p>
+    <!-- placeholder: dashboard screenshot -->
+    <img src="assets/images/screenshot-dashboard.png" alt="Live dashboard screenshot">
+  </article>
+
+  <article>
+    <h2>Smart Forecasting</h2>
+    <p>Get real-time predictions for today, this week, this month, and year.</p>
+    <!-- placeholder: forecasting view -->
+    <img src="assets/images/screenshot-forecast.png" alt="Forecasting screenshot">
+  </article>
+
+  <article>
+    <h2>Custom Goals & Reminders</h2>
+    <p>Set distance or workout-count targets and receive intelligent nudges.</p>
+    <!-- placeholder: goals/reminders view -->
+    <img src="assets/images/screenshot-goals.png" alt="Goals & reminders screenshot">
+  </article>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>On Pace For</title>
+  <meta name="description" content="Log workouts & predict your daily, weekly, monthly & yearly fitness goals.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <!-- Hero -->
+  <section id="hero">
+    <h1>Turn Every Workout into Clear Progress</h1>
+    <p>Automatically track your activity and forecast your goals.</p>
+    <a href="https://apps.apple.com/app/idYOUR_APP_ID" class="btn">Download on the App Store</a>
+    <!-- placeholder: replace with real hero screenshot -->
+    <img src="assets/images/screenshot-hero.png" alt="App hero screenshot">
+  </section>
+
+  <!-- Quick links -->
+  <nav>
+    <ul>
+      <li><a href="features.html">Features</a></li>
+      <li><a href="pricing.html">Pricing</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+</body>
+</html>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pricing — On Pace For</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header><a href="index.html">← Home</a></header>
+  <h1>Pricing</h1>
+  <section>
+    <h2>Free Beta</h2>
+    <p>All core features at no cost—invite-only beta access.</p>
+  </section>
+  <section>
+    <h2>Future Premium</h2>
+    <p>Extra analytics, group challenges, custom themes. Coming soon.</p>
+  </section>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,8 @@
+/* Placeholder styles */
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+#hero { text-align: center; padding: 2rem; }
+nav ul { list-style: none; display: flex; justify-content: center; gap: 1rem; padding: 0; }
+nav a { text-decoration: none; }
+.btn { display: inline-block; margin-top: 1rem; padding: 0.5rem 1rem; background: #007BFF; color: white; border-radius: 4px; }
+header a { text-decoration: none; }
+article { margin: 2rem 0; }


### PR DESCRIPTION
## Summary
- scaffold static site with index, features, pricing, and contact pages
- add placeholder images
- include simple styles
- remove placeholder screenshots

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68479621eae88322b26a37ba19d80d26